### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a single **Next.js 15 + Nextra 4** static blog (`cloudea-blog-nextra`). There is no backend, database, or automated test suite (a `vitest` dependency exists but there are no test files or `test` script). Standard scripts live in `package.json` (`dev`, `build`, `start`, `postbuild`). Toolchain: Node 22 + pnpm 11.1.2. The update script runs `pnpm install` on startup.
+
+Non-obvious caveats:
+
+- **A `.env` file is required for `pnpm build` (and correct dev metadata).** `app/_components/navbar/stack.tsx` computes `process.env.NEXT_PUBLIC_BASE_URL! + process.env.NEXT_PUBLIC_BASE_PATH` and passes it to `new URL(...)`. With those vars unset the expression evaluates to `NaN`, so the build fails with `TypeError: Invalid URL ... input: 'NaN'` while collecting the `/categories` pages. `.env` is gitignored; create it once from `.env.example` (`NEXT_PUBLIC_BASE_URL="http://localhost:3000"`, `NEXT_PUBLIC_BASE_PATH=""`) if it is missing.
+- **Search does not work under `pnpm dev`.** Nextra 4 search uses Pagefind, which indexes built `.html` files; the dev server shows "Failed to load search index". To exercise search, run `pnpm build` (its `postbuild` step runs Pagefind into `out/_pagefind`) and serve the static export from `out/`, e.g. `npx serve out -l 4000`. Note `next.config.ts` sets `output: "export"`, so `next start` is not the right way to preview; serve the `out/` directory with any static server.
+- **Lint:** there is no `lint` script; run ESLint directly with `npx eslint .`. As of setup it reports 2 pre-existing errors in `mdx-components.tsx` and 1 warning in `app/_components/sidebar.tsx` (not caused by env setup).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for this Next.js 15 + Nextra 4 static blog so future Cursor Cloud agents can build/run/lint reliably.

Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section capturing non-obvious caveats discovered during setup:

- **`.env` is required for `pnpm build`** — `app/_components/navbar/stack.tsx` builds a URL from `NEXT_PUBLIC_BASE_URL`/`NEXT_PUBLIC_BASE_PATH`; when unset the expression evaluates to `NaN` and the build fails with `TypeError: Invalid URL ... input: 'NaN'`. `.env` is gitignored; create it from `.env.example`.
- **Search only works against a production build** — Nextra 4 uses Pagefind, which indexes built HTML, so search is unavailable under `pnpm dev`. Run `pnpm build` and serve `out/` (e.g. `npx serve out`) to exercise it. `output: "export"` means `next start` is not the preview path.
- **Lint** — no `lint` script; run `npx eslint .` (2 pre-existing errors + 1 warning unrelated to setup).

No application/source code was modified.

## Environment role split

- **Update script** (minimal, runs on VM startup): `pnpm install`
- **AGENTS.md**: durable, non-obvious startup/run guidance for future agents

## Verification

- `pnpm install` — deps installed (Node 22, pnpm 11.1.2)
- `pnpm build` — succeeds after adding `.env` (static export + Pagefind index)
- `npx eslint .` — runs (pre-existing errors only)
- `pnpm dev` — homepage, post navigation, and article rendering verified in browser
- Production preview (`npx serve out`) — Pagefind search verified end-to-end

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9bdefb3-c1b8-46e3-b1ce-1348e7e54a0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9bdefb3-c1b8-46e3-b1ce-1348e7e54a0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

